### PR TITLE
Parse SEND_LONG_DATA commands

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,6 +306,7 @@ impl<B: MysqlShim<W>, R: Read, W: Write> MysqlIntermediary<B, R, W> {
 
                     self.shim.on_execute(stmt, params, w)?;
                 }
+                Command::SendLongData { stmt, param, data } => unimplemented!(),
                 Command::Close(stmt) => {
                     self.shim.on_close(stmt);
                     // NOTE: spec dictates no response from server


### PR DESCRIPTION
MySQL sends "long" parameters using `SEND_LONG_DATA` commands:
https://github.com/MariaDB/server/blob/10.3/sql/sql_prepare.cc#L73-L84

This happens, for example, if a `VARCHAR` field is used as a parameter.

This change adds support for parsing these commands, but leaves their handling `unimplemented!()` as we'll need to decide whether to keep parameter state in msql_str or force the implementing library to store it (via `on_send_long_data` or similar).