### PR TITLE
do not panic on list fields requests

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -30,6 +30,7 @@ named!(
 #[derive(Debug, PartialEq, Eq)]
 pub enum Command<'a> {
     Query(&'a [u8]),
+    ListFields(&'a [u8]),
     Close(u32),
     Prepare(&'a [u8]),
     Init(&'a [u8]),
@@ -78,6 +79,7 @@ named!(
     pub parse<Command>,
     alt!(
         preceded!(tag!(&[CommandByte::COM_QUERY as u8]), apply!(nom::rest,)) => { |sql| Command::Query(sql) } |
+        preceded!(tag!(&[CommandByte::COM_FIELD_LIST as u8]), apply!(nom::rest,)) => { |filter| Command::ListFields(filter) } |
         preceded!(tag!(&[CommandByte::COM_INIT_DB as u8]), apply!(nom::rest,)) => { |db| Command::Init(db) } |
         preceded!(tag!(&[CommandByte::COM_STMT_PREPARE as u8]), apply!(nom::rest,)) => { |sql| Command::Prepare(sql) } |
         preceded!(tag!(&[CommandByte::COM_STMT_EXECUTE as u8]), execute) |
@@ -146,6 +148,26 @@ mod tests {
         assert_eq!(
             cmd,
             Command::Query(&b"select @@version_comment limit 1"[..])
+        );
+    }
+use std::str;
+    #[test]
+    fn it_handles_list_fields(){
+       // mysql_list_fields (CommandByte::COM_FIELD_LIST / 0x04) has been deprecated in mysql 5.7 and will be removed
+       // in a future version. The mysql command line tool issues one of these commands after
+       // switching databases with USE <DB>.
+        let data = &[
+            0x21, 0x00, 0x00, 0x00, 0x04, 0x73, 0x65, 0x6c, 0x65, 0x63, 0x74, 0x20, 0x40, 0x40,
+            0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x5f, 0x63, 0x6f, 0x6d, 0x6d, 0x65, 0x6e,
+            0x74, 0x20, 0x6c, 0x69, 0x6d, 0x69, 0x74, 0x20, 0x31,
+        ];
+        let r = Cursor::new(&data[..]);
+        let mut pr = PacketReader::new(r);
+        let (_, p) = pr.next().unwrap().unwrap();
+        let (_, cmd) = parse(&p).unwrap();
+        assert_eq!(
+            cmd,
+            Command::ListFields(&b"select @@version_comment limit 1"[..])
         );
     }
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -150,7 +150,7 @@ mod tests {
             Command::Query(&b"select @@version_comment limit 1"[..])
         );
     }
-use std::str;
+
     #[test]
     fn it_handles_list_fields(){
        // mysql_list_fields (CommandByte::COM_FIELD_LIST / 0x04) has been deprecated in mysql 5.7 and will be removed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,6 +329,15 @@ impl<B: MysqlShim<W>, R: Read, W: Write> MysqlIntermediary<B, R, W> {
                     stmts.remove(&stmt);
                     // NOTE: spec dictates no response from server
                 }
+                Command::ListFields(_) => {
+                    let cols = &[Column {
+                        table: String::new(),
+                        column: "not implemented".to_owned(),
+                        coltype: myc::constants::ColumnType::MYSQL_TYPE_SHORT,
+                        colflags: myc::constants::ColumnFlags::UNSIGNED_FLAG,
+                    }];
+                    writers::write_column_definitions(cols, &mut self.writer, true);
+                }
                 Command::Init(_) | Command::Ping => {
                     writers::write_ok_packet(&mut self.writer, 0, 0, StatusFlags::empty())?;
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,7 +336,7 @@ impl<B: MysqlShim<W>, R: Read, W: Write> MysqlIntermediary<B, R, W> {
                         coltype: myc::constants::ColumnType::MYSQL_TYPE_SHORT,
                         colflags: myc::constants::ColumnFlags::UNSIGNED_FLAG,
                     }];
-                    writers::write_column_definitions(cols, &mut self.writer, true);
+                    writers::write_column_definitions(cols, &mut self.writer, true)?;
                 }
                 Command::Init(_) | Command::Ping => {
                     writers::write_ok_packet(&mut self.writer, 0, 0, StatusFlags::empty())?;


### PR DESCRIPTION
Hi,

The mysql client issues a COM_FIELD_LIST after the user switches databases with "USE [DB]". This caused the thread to panic with a parse error.

COM_FIELD_LIST / mysql_list_fields() is deprecated as of MySQL 5.7.11 and will be removed in a future version. This pull request implements enough of the COM_FIELD_LIST to avoid the panic by returning a single ColumnDefinition "not implemented".

I considered adding on_list_fields() to the MysqlShim trait however given the deprecation I suppose the client will eventually stop issuing those calls.

cheers,
james