### PR TITLE
Bump time dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ nom = "5"
 mysql_common = "0.22"
 byteorder = "1"
 chrono = "0.4"
-time = "=0.2.7"
+time = "0.2.25"
 
 [dev-dependencies]
 postgres = "0.15"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,10 +1,8 @@
 jobs:
- - template: default.yml@templates
-   parameters:
-     minrust: 1.39.0 # bytes
-     # re-enable coverage when we're on a newer version of time:
-     # https://github.com/time-rs/time/pull/265
-     # codecov_token: $(CODECOV_TOKEN_SECRET)
+  - template: default.yml@templates
+    parameters:
+      minrust: 1.42
+      codecov_token: $(CODECOV_TOKEN_SECRET)
 
 resources:
   repositories:


### PR DESCRIPTION
Bumps the `time` dependency version to `0.2.25` 

This is being done because a dependency issue with `time` was encountered when working with `msql-srv` and `actix-web` together in one project. More information can be found in #15.