### PR TITLE
Fix time field length when us=0

### DIFF
--- a/src/value/decode.rs
+++ b/src/value/decode.rs
@@ -254,28 +254,28 @@ impl<'a> Into<Duration> for Value<'a> {
             assert!(v.len() == 0 || v.len() == 8 || v.len() == 12);
 
             if v.len() == 0 {
-                Duration::from_secs(0)
-            } else {
-                let neg = v.read_u8().unwrap();
-                if neg != 0u8 {
-                    unimplemented!();
-                }
-
-                let days = u64::from(v.read_u32::<LittleEndian>().unwrap());
-                let hours = u64::from(v.read_u8().unwrap());
-                let minutes = u64::from(v.read_u8().unwrap());
-                let seconds = u64::from(v.read_u8().unwrap());
-                let micros = if v.len() == 12 {
-                    v.read_u32::<LittleEndian>().unwrap()
-                } else {
-                    0
-                };
-
-                Duration::new(
-                    days * 86_400 + hours * 3_600 + minutes * 60 + seconds,
-                    micros * 1_000,
-                )
+                return Duration::from_secs(0);
             }
+
+            let neg = v.read_u8().unwrap();
+            if neg != 0u8 {
+                unimplemented!();
+            }
+
+            let days = u64::from(v.read_u32::<LittleEndian>().unwrap());
+            let hours = u64::from(v.read_u8().unwrap());
+            let minutes = u64::from(v.read_u8().unwrap());
+            let seconds = u64::from(v.read_u8().unwrap());
+            let micros = if v.len() == 12 {
+                v.read_u32::<LittleEndian>().unwrap()
+            } else {
+                0
+            };
+
+            Duration::new(
+                days * 86_400 + hours * 3_600 + minutes * 60 + seconds,
+                micros * 1_000,
+            )
         } else {
             panic!("invalid type conversion from {:?} to datetime", self)
         }

--- a/src/value/encode.rs
+++ b/src/value/encode.rs
@@ -530,7 +530,7 @@ impl ToMysqlValue for Duration {
                 if us != 0 {
                     w.write_u8(12u8)?;
                 } else {
-                    w.write_u8(9u8)?;
+                    w.write_u8(8u8)?;
                 }
 
                 w.write_u8(0u8)?; // positive only (for now)

--- a/src/value/encode.rs
+++ b/src/value/encode.rs
@@ -527,20 +527,24 @@ impl ToMysqlValue for Duration {
 
         match c.coltype {
             ColumnType::MYSQL_TYPE_TIME => {
-                if us != 0 {
-                    w.write_u8(12u8)?;
+                if self.as_secs() == 0 && us == 0 {
+                    w.write_u8(0u8)?;
                 } else {
-                    w.write_u8(8u8)?;
-                }
+                    if us != 0 {
+                        w.write_u8(12u8)?;
+                    } else {
+                        w.write_u8(8u8)?;
+                    }
 
-                w.write_u8(0u8)?; // positive only (for now)
-                w.write_u32::<LittleEndian>(d as u32)?;
-                w.write_u8(h as u8)?;
-                w.write_u8(m as u8)?;
-                w.write_u8(s as u8)?;
+                    w.write_u8(0u8)?; // positive only (for now)
+                    w.write_u32::<LittleEndian>(d as u32)?;
+                    w.write_u8(h as u8)?;
+                    w.write_u8(m as u8)?;
+                    w.write_u8(s as u8)?;
 
-                if us != 0 {
-                    w.write_u32::<LittleEndian>(us)?;
+                    if us != 0 {
+                        w.write_u32::<LittleEndian>(us)?;
+                    }
                 }
                 Ok(())
             }
@@ -719,6 +723,8 @@ mod tests {
             chrono::Utc.ymd(1989, 12, 7).and_hms(8, 0, 4).naive_utc()
         );
         rt!(dur, time::Duration, time::Duration::from_secs(1893));
+        rt!(dur_micro, time::Duration, time::Duration::new(1893, 5000));
+        rt!(dur_zero, time::Duration, time::Duration::from_secs(0));
         rt!(bytes, Vec<u8>, vec![0x42, 0x00, 0x1a]);
         rt!(string, String, "foobar".to_owned());
     }


### PR DESCRIPTION
I noticed this when testing using sqlx client and getting off by one errors, time length should be [0, 8, 12]

https://dev.mysql.com/doc/internals/en/binary-protocol-value.html