### PR TITLE
Enable returning errors after creating row writer

### DIFF
--- a/src/resultset.rs
+++ b/src/resultset.rs
@@ -390,7 +390,10 @@ impl<'a, W: Write + 'a> RowWriter<'a, W> {
     }
 
     /// End this resultset response, and indicate to the client there was an error.
-    pub fn finish_error<E>(mut self, kind: ErrorKind, msg: &E) -> io::Result<()> where E: Borrow<[u8]> {
+    pub fn finish_error<E>(mut self, kind: ErrorKind, msg: &E) -> io::Result<()>
+    where
+        E: Borrow<[u8]>,
+    {
         self.finish_inner(false)?;
 
         self.result.take().unwrap().error(kind, msg)

--- a/src/resultset.rs
+++ b/src/resultset.rs
@@ -357,6 +357,10 @@ impl<'a, W: Write + 'a> RowWriter<'a, W> {
             self.end_row()?;
         }
 
+        Ok(())
+    }
+
+    fn finish_completed(&mut self) -> io::Result<()> {
         if self.columns.is_empty() {
             // response to no column query is always an OK packet
             // we've kept track of the number of rows in col (hacky, I know)
@@ -368,12 +372,17 @@ impl<'a, W: Write + 'a> RowWriter<'a, W> {
             // we wrote out at least one row
             self.result.as_mut().unwrap().last_end = Some(Finalizer::EOF);
         }
+
         Ok(())
     }
 
     /// Indicate to the client that no more rows are coming.
-    pub fn finish(self) -> io::Result<()> {
-        self.finish_one()?.no_more_results()
+    pub fn finish(mut self) -> io::Result<()> {
+        self.finish_inner()?;
+
+        self.finish_completed()?;
+
+        self.result.take().unwrap().no_more_results()
     }
 
     /// End this resultset response, and indicate to the client that no more rows are coming.
@@ -382,6 +391,11 @@ impl<'a, W: Write + 'a> RowWriter<'a, W> {
         // we know that dropping self will see self.finished == true,
         // and so Drop won't try to use self.result.
         Ok(self.result.take().unwrap())
+    }
+
+    /// End this resultset response, and indicate to the client there was an error.
+    pub fn finish_error<E>(self, kind: ErrorKind, msg: &E) -> io::Result<()> where E: Borrow<[u8]> {
+        self.finish_one()?.error(kind, msg)
     }
 }
 

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -279,34 +279,28 @@ fn error_in_result_set_response() {
             }];
             let mut w = w.start(cols)?;
             w.write_col(1024)?;
-            w.finish_error( err.0, &err.1.as_bytes())
+            w.finish_error(err.0, &err.1.as_bytes())
         },
         |_| unreachable!(),
         |_, _, _| unreachable!(),
         |_, _| unreachable!(),
     )
     .test(|db| {
-            let mut result = db
-                .query_iter("SELECT a FROM foo")
-                .unwrap();
-            let row1 = result.next().unwrap().unwrap().get::<i16, _>(0).unwrap();
-            assert_eq!(row1, 1024);
-            if let mysql::Error::MySqlError(e) = result
-                .by_ref()
-                .next()
-                .unwrap()
-                .unwrap_err() {
-                    assert_eq!(
-                        e,
-                        mysql::error::MySqlError {
-                            state: String::from_utf8(err.0.sqlstate().to_vec()).unwrap(),
-                            message: err.1.to_owned(),
-                            code: err.0 as u16,
-                        }
-                    );
-                } else {
-                    unreachable!()
+        let mut result = db.query_iter("SELECT a FROM foo").unwrap();
+        let row1 = result.next().unwrap().unwrap().get::<i16, _>(0).unwrap();
+        assert_eq!(row1, 1024);
+        if let mysql::Error::MySqlError(e) = result.by_ref().next().unwrap().unwrap_err() {
+            assert_eq!(
+                e,
+                mysql::error::MySqlError {
+                    state: String::from_utf8(err.0.sqlstate().to_vec()).unwrap(),
+                    message: err.1.to_owned(),
+                    code: err.0 as u16,
                 }
+            );
+        } else {
+            unreachable!()
+        }
     })
 }
 

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -267,6 +267,50 @@ fn error_response() {
 }
 
 #[test]
+fn error_in_result_set_response() {
+    let err = (ErrorKind::ER_NO, "clearly not");
+    TestingShim::new(
+        move |_, w| {
+            let cols = &[Column {
+                table: String::new(),
+                column: "a".to_owned(),
+                coltype: myc::constants::ColumnType::MYSQL_TYPE_SHORT,
+                colflags: myc::constants::ColumnFlags::empty(),
+            }];
+            let mut w = w.start(cols)?;
+            w.write_col(1024)?;
+            w.finish_error( err.0, &err.1.as_bytes())
+        },
+        |_| unreachable!(),
+        |_, _, _| unreachable!(),
+        |_, _| unreachable!(),
+    )
+    .test(|db| {
+            let mut result = db
+                .query_iter("SELECT a FROM foo")
+                .unwrap();
+            let row1 = result.next().unwrap().unwrap().get::<i16, _>(0).unwrap();
+            assert_eq!(row1, 1024);
+            if let mysql::Error::MySqlError(e) = result
+                .by_ref()
+                .next()
+                .unwrap()
+                .unwrap_err() {
+                    assert_eq!(
+                        e,
+                        mysql::error::MySqlError {
+                            state: String::from_utf8(err.0.sqlstate().to_vec()).unwrap(),
+                            message: err.1.to_owned(),
+                            code: err.0 as u16,
+                        }
+                    );
+                } else {
+                    unreachable!()
+                }
+    })
+}
+
+#[test]
 fn empty_on_drop() {
     let cols = [Column {
         table: String::new(),


### PR DESCRIPTION
So the issue I have is that once you create a `RowWriter` you aren't able to return an error anymore because when you call `finish_one` to get `QueryResultWriter` the client just assumes we reached the end of the result set and doesn't see the error message.

I don't think this is a total solution but works for my use case, I think the correct solution would be to either adding a `finish_error` function to `RowWriter` or to not set `last_end` if you call `finish_one`? But I'm not sure if that is a problem for other use cases.