### PR TITLE
Basic tls support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ chrono = "0.4"
 time = "0.2.25"
 
 [dev-dependencies]
-postgres = "0.15"
+postgres = "0.19.1"
 mysql = "18"
 mysql_async = "0.20.0"
 slab = "0.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ mysql_common = "0.22"
 byteorder = "1"
 chrono = "0.4"
 time = "0.2.25"
+rustls = "0.20.0-beta2"
+readwrite = "0.2.0"
+rustls-pemfile = "0.2.1"
 
 [dev-dependencies]
 postgres = "0.19.1"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 jobs:
   - template: default.yml@templates
     parameters:
-      minrust: 1.42
+      minrust: 1.54
       codecov_token: $(CODECOV_TOKEN_SECRET)
 
 resources:

--- a/examples/serve_one.rs
+++ b/examples/serve_one.rs
@@ -14,23 +14,23 @@ use std::net;
 use std::thread;
 
 struct Backend;
-impl<W: io::Write> MysqlShim<W> for Backend {
+impl MysqlShim for Backend {
     type Error = io::Error;
 
-    fn on_prepare(&mut self, _: &str, info: StatementMetaWriter<W>) -> io::Result<()> {
+    fn on_prepare(&mut self, _: &str, info: StatementMetaWriter) -> io::Result<()> {
         info.reply(42, &[], &[])
     }
     fn on_execute(
         &mut self,
         _: u32,
         _: msql_srv::ParamParser,
-        results: QueryResultWriter<W>,
+        results: QueryResultWriter,
     ) -> io::Result<()> {
         results.completed(0, 0)
     }
     fn on_close(&mut self, _: u32) {}
 
-    fn on_query(&mut self, _: &str, results: QueryResultWriter<W>) -> io::Result<()> {
+    fn on_query(&mut self, _: &str, results: QueryResultWriter) -> io::Result<()> {
         results.start(&[])?.finish()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,8 @@ use std::io::prelude::*;
 use std::iter;
 use std::net;
 
+use myc::constants::CapabilityFlags;
+
 pub use crate::myc::constants::{ColumnFlags, ColumnType, StatusFlags};
 
 mod commands;
@@ -108,6 +110,7 @@ mod errorcodes;
 mod packet;
 mod params;
 mod resultset;
+mod tls;
 mod value;
 mod writers;
 
@@ -134,6 +137,7 @@ pub struct Column {
 pub use crate::errorcodes::ErrorKind;
 pub use crate::params::{ParamParser, ParamValue, Params};
 pub use crate::resultset::{InitWriter, QueryResultWriter, RowWriter, StatementMetaWriter};
+pub use crate::tls::TlsConfig;
 pub use crate::value::{ToMysqlValue, Value, ValueInner};
 
 /// Implementors of this trait can be used to drive a MySQL-compatible database backend.
@@ -176,6 +180,11 @@ pub trait MysqlShim {
     /// Called when client switches database.
     fn on_init(&mut self, _: &str, _: InitWriter<'_>) -> Result<(), Self::Error> {
         Ok(())
+    }
+
+    /// Provides the TLS configuration, if we want to support TLS.
+    fn tls_config(&self) -> Option<&TlsConfig> {
+        None
     }
 }
 
@@ -231,11 +240,11 @@ impl<B: MysqlShim> MysqlIntermediary<B> {
             reader: r,
             writer: w,
         };
-        mi.init()?;
+        mi = mi.init()?;
         mi.run()
     }
 
-    fn init(&mut self) -> Result<(), B::Error> {
+    fn init(mut self) -> Result<Self, B::Error> {
         self.writer.write_all(&[10])?; // protocol 10
 
         // 5.1.10 because that's what Ruby's ActiveRecord requires
@@ -243,7 +252,11 @@ impl<B: MysqlShim> MysqlIntermediary<B> {
 
         self.writer.write_all(&[0x08, 0x00, 0x00, 0x00])?; // TODO: connection ID
         self.writer.write_all(&b";X,po_k}\0"[..])?; // auth seed
-        self.writer.write_all(&[0x00, 0x42])?; // just 4.1 proto
+        let capabilities = &mut [0x00, 0x42]; // 4.1 proto
+        if self.shim.tls_config().is_some() {
+            capabilities[1] |= 0x08; // SSL support flag
+        }
+        self.writer.write_all(capabilities)?;
         self.writer.write_all(&[0x21])?; // UTF8_GENERAL_CI
         self.writer.write_all(&[0x00, 0x00])?; // status flags
         self.writer.write_all(&[0x00, 0x00])?; // extended capabilities
@@ -260,7 +273,7 @@ impl<B: MysqlShim> MysqlIntermediary<B> {
                     "peer terminated connection",
                 )
             })?;
-            let _handshake = commands::client_handshake(&handshake)
+            let handshake = commands::client_handshake(&handshake)
                 .map_err(|e| match e {
                     nom::Err::Incomplete(_) => io::Error::new(
                         io::ErrorKind::UnexpectedEof,
@@ -282,13 +295,67 @@ impl<B: MysqlShim> MysqlIntermediary<B> {
                     }
                 })?
                 .1;
+
             self.writer.set_seq(seq + 1);
+
+            if handshake.capabilities.contains(CapabilityFlags::CLIENT_SSL) {
+                let config = self.shim.tls_config().ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "client requested SSL despite us not advertising support for it",
+                    )
+                })?;
+
+                assert!(self.reader.remaining() == 0); // otherwise we've read ahead into the TLS handshake and will be in trouble.
+
+                let rw = readwrite::ReadWrite::new(self.reader.r, self.writer.w);
+
+                let stream1 = tls::create_stream(rw, &config)?;
+                let stream2 = stream1.clone();
+
+                self.reader.r = Box::new(stream1);
+                self.writer.w = Box::new(stream2);
+
+                let (seq, handshake) = self.reader.next()?.ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::ConnectionAborted,
+                        "peer terminated connection",
+                    )
+                })?;
+                let _handshake = commands::client_handshake(&handshake)
+                    .map_err(|e| match e {
+                        nom::Err::Incomplete(_) => io::Error::new(
+                            io::ErrorKind::UnexpectedEof,
+                            "client sent incomplete handshake",
+                        ),
+                        nom::Err::Failure((input, nom_e_kind))
+                        | nom::Err::Error((input, nom_e_kind)) => {
+                            if let nom::error::ErrorKind::Eof = nom_e_kind {
+                                io::Error::new(
+                                    io::ErrorKind::UnexpectedEof,
+                                    format!("client did not complete handshake; got {:?}", input),
+                                )
+                            } else {
+                                io::Error::new(
+                                    io::ErrorKind::InvalidData,
+                                    format!(
+                                        "bad client handshake; got {:?} ({:?})",
+                                        input, nom_e_kind
+                                    ),
+                                )
+                            }
+                        }
+                    })?
+                    .1;
+
+                self.writer.set_seq(seq + 1);
+            }
         }
 
         writers::write_ok_packet(&mut self.writer, 0, 0, StatusFlags::empty())?;
         self.writer.flush()?;
 
-        Ok(())
+        Ok(self)
     }
 
     fn run(mut self) -> Result<(), B::Error> {

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -5,9 +5,9 @@ use std::io::prelude::*;
 const U24_MAX: usize = 16_777_215;
 
 pub struct PacketWriter {
-    to_write: Vec<u8>,
+    pub(crate) to_write: Vec<u8>,
     seq: u8,
-    w: Box<dyn Write>,
+    pub(crate) w: Box<dyn Write>,
 }
 
 impl Write for PacketWriter {
@@ -65,7 +65,7 @@ pub struct PacketReader {
     bytes: Vec<u8>,
     start: usize,
     remaining: usize,
-    r: Box<dyn Read>,
+    pub(crate) r: Box<dyn Read>,
 }
 
 impl PacketReader {
@@ -131,6 +131,10 @@ impl PacketReader {
                 }
             }
         }
+    }
+
+    pub fn remaining(&self) -> usize {
+        self.remaining
     }
 }
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,0 +1,138 @@
+use std::io::{BufReader, Read, Write};
+use std::sync::{Arc, Mutex};
+use std::{fs, io};
+
+use rustls::{self, Connection, NoClientAuth, ServerConfig, ServerConnection};
+
+/// TLS configuration
+#[derive(Clone)]
+pub struct TlsConfig {
+    /// Full path to the server certificate file.
+    pub server_cert: String,
+    /// Full path to the server key file.
+    pub server_cert_key: String,
+}
+
+fn make_config(config: &TlsConfig) -> Result<Arc<rustls::ServerConfig>, io::Error> {
+    let builder = ServerConfig::builder()
+        .with_safe_default_cipher_suites()
+        .with_safe_default_kx_groups()
+        .with_safe_default_protocol_versions()
+        .map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                "inconsistent cipher-suites/versions specified",
+            )
+        })?
+        .with_client_cert_verifier(NoClientAuth::new());
+
+    let mut server_config = {
+        let certs = load_cert(&config.server_cert)?;
+        let privkey = load_private_key(&config.server_cert_key)?;
+
+        builder
+            .with_single_cert(certs, privkey)
+            .map_err(|_| io::Error::new(io::ErrorKind::Other, "bad certificates/private key"))?
+    };
+
+    server_config.key_log = Arc::new(rustls::KeyLogFile::new());
+
+    Ok(Arc::new(server_config))
+}
+
+fn load_cert(filename: &str) -> Result<Vec<rustls::Certificate>, io::Error> {
+    let certfile = fs::File::open(filename)?;
+    let mut reader = BufReader::new(certfile);
+    Ok(rustls_pemfile::certs(&mut reader)?
+        .iter()
+        .map(|v| rustls::Certificate(v.clone()))
+        .collect())
+}
+
+fn load_private_key(filename: &str) -> Result<rustls::PrivateKey, io::Error> {
+    let keyfile = fs::File::open(filename)?;
+    let mut reader = BufReader::new(keyfile);
+
+    loop {
+        match rustls_pemfile::read_one(&mut reader).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "cannot parse private key .pem file",
+            )
+        })? {
+            Some(rustls_pemfile::Item::RSAKey(key)) => return Ok(rustls::PrivateKey(key)),
+            Some(rustls_pemfile::Item::PKCS8Key(key)) => return Ok(rustls::PrivateKey(key)),
+            None => break,
+            _ => {}
+        }
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::Other,
+        format!(
+            "no keys found in {:?} (encrypted keys not supported)",
+            filename
+        ),
+    ))
+}
+
+pub struct TlsStream<C: Connection + Sized, T: Read + Write + Sized> {
+    stream: Arc<Mutex<rustls::StreamOwned<C, T>>>,
+}
+
+impl<C, T> Clone for TlsStream<C, T>
+where
+    C: Connection,
+    T: Read + Write,
+{
+    fn clone(&self) -> Self {
+        TlsStream {
+            stream: Arc::clone(&self.stream),
+        }
+    }
+}
+
+impl<C, T> Write for TlsStream<C, T>
+where
+    C: Connection,
+    T: Read + Write,
+{
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let stream = &mut self.stream.lock().unwrap();
+
+        stream.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        let stream = &mut self.stream.lock().unwrap();
+
+        stream.flush()?;
+
+        Ok(())
+    }
+}
+
+impl<C, T> Read for TlsStream<C, T>
+where
+    C: Connection,
+    T: Read + Write,
+{
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let stream = &mut self.stream.lock().unwrap();
+
+        stream.read(buf)
+    }
+}
+
+pub fn create_stream<S: Read + Write>(
+    sock: S,
+    config: &TlsConfig,
+) -> Result<TlsStream<ServerConnection, S>, io::Error> {
+    let config = make_config(config)?;
+
+    let conn = ServerConnection::new(config).unwrap();
+
+    let stream = Arc::new(Mutex::new(rustls::StreamOwned { conn, sock }));
+
+    Ok(TlsStream { stream })
+}


### PR DESCRIPTION
This adds initial support for TLS connections.

The basic approach to doing this was:
1) Make the `Read` and `Write` on `PacketReader` and `PacketWriter` dynamic so they can be swapped out if needed later.  (Note that this is an API change, because it resulted in a bunch of generics disappearing)
2) During the handshake, if we want TLS, do the TLS handshake and swap the aforementioned `Read` / `Write` instances with their TLS enabled counterparts.

The two changes listed are done in separate commits for ease of review.

Note that TLS is entirely optional,  The client can still not use TLS when it's configured on the server of course, but it's also optional on the server, depending whether the `Shim` implementation returns a `TlsConfig` or not.