### PR TITLE
Upgrade mysql_common to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 nom = "5"
-mysql_common = "0.22"
+mysql_common = { version = "0.28.0", features = ["chrono"] }
 byteorder = "1"
 chrono = "0.4"
 time = "0.2.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msql-srv"
-version = "0.9.5"
+version = "0.9.6"
 edition = "2018"
 
 description = "Bindings for emulating a MySQL/MariaDB server"

--- a/examples/psql_as_mysql.rs
+++ b/examples/psql_as_mysql.rs
@@ -9,6 +9,7 @@ extern crate slab;
 
 use msql_srv::*;
 use mysql::prelude::*;
+use mysql::Opts;
 use slab::Slab;
 
 use std::io;
@@ -29,7 +30,8 @@ fn main() {
     });
 
     // we connect using MySQL bindings, but no MySQL server is running!
-    let mut db = mysql::Conn::new(&format!("mysql://127.0.0.1:{}", port)).unwrap();
+    let mut db =
+        mysql::Conn::new(Opts::from_url(&format!("mysql://127.0.0.1:{}", port)).unwrap()).unwrap();
     assert_eq!(db.ping(), true);
     {
         let mut results = db

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 //! # use std::thread;
 //! use msql_srv::*;
 //! use mysql::prelude::*;
+//! use mysql::Opts;
 //!
 //! struct Backend;
 //! impl<W: io::Write> MysqlShim<W> for Backend {
@@ -73,7 +74,7 @@
 //!         }
 //!     });
 //!
-//!     let mut db = mysql::Conn::new(&format!("mysql://127.0.0.1:{}", port)).unwrap();
+//!     let mut db = mysql::Conn::new(Opts::from_url(&format!("mysql://127.0.0.1:{}", port)).unwrap()).unwrap();
 //!     assert_eq!(db.ping(), true);
 //!     assert_eq!(db.query_iter("SELECT a, b FROM foo").unwrap().count(), 1);
 //!     drop(db);

--- a/src/params.rs
+++ b/src/params.rs
@@ -74,8 +74,8 @@ impl<'a> Iterator for Params<'a> {
                 for i in 0..self.params as usize {
                     self.bound_types.push((
                         myc::constants::ColumnType::try_from(typmap[2 * i as usize])
-                            .unwrap_or_else(|_| {
-                                panic!("got unsupported column type 0x{:x}", typmap[2 * i as usize])
+                            .unwrap_or_else(|e| {
+                                panic!("bad column type 0x{:x}: {}", typmap[2 * i as usize], e)
                             }),
                         (typmap[2 * i as usize + 1] & 128) != 0,
                     ));

--- a/src/params.rs
+++ b/src/params.rs
@@ -1,6 +1,7 @@
 use crate::myc;
 use crate::{StatementData, Value};
 use std::collections::HashMap;
+use std::convert::TryFrom;
 
 /// A `ParamParser` decodes query parameters included in a client's `EXECUTE` command given
 /// type information for the expected parameters.
@@ -72,7 +73,7 @@ impl<'a> Iterator for Params<'a> {
                 self.bound_types.clear();
                 for i in 0..self.params as usize {
                     self.bound_types.push((
-                        myc::constants::ColumnType::from(typmap[2 * i as usize]),
+                        myc::constants::ColumnType::try_from(typmap[2 * i as usize]).unwrap(),
                         (typmap[2 * i as usize + 1] & 128) != 0,
                     ));
                 }

--- a/src/params.rs
+++ b/src/params.rs
@@ -73,7 +73,10 @@ impl<'a> Iterator for Params<'a> {
                 self.bound_types.clear();
                 for i in 0..self.params as usize {
                     self.bound_types.push((
-                        myc::constants::ColumnType::try_from(typmap[2 * i as usize]).unwrap(),
+                        myc::constants::ColumnType::try_from(typmap[2 * i as usize])
+                            .unwrap_or_else(|_| {
+                                panic!("got unsupported column type 0x{:x}", typmap[2 * i as usize])
+                            }),
                         (typmap[2 * i as usize + 1] & 128) != 0,
                     ));
                 }

--- a/src/value/decode.rs
+++ b/src/value/decode.rs
@@ -290,6 +290,7 @@ mod tests {
     use crate::myc::io::WriteMysqlExt;
     use crate::{Column, ColumnFlags, ColumnType};
     use chrono::{self, TimeZone};
+    use myc::proto::MySerialize;
     use std::time;
 
     macro_rules! rt {
@@ -312,7 +313,7 @@ mod tests {
                 }
 
                 let v: $t = $v;
-                data.write_bin_value(&myc::value::Value::from(v)).unwrap();
+                myc::value::Value::from(v).serialize(&mut data);
                 assert_eq!(
                     Into::<$t>::into(Value::parse_from(&mut &data[..], $ct, !$sig).unwrap()),
                     v

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -5,6 +5,7 @@ extern crate mysql_common as myc;
 extern crate nom;
 
 use mysql::prelude::*;
+use mysql::Opts;
 use std::io;
 use std::net;
 use std::thread;
@@ -106,7 +107,9 @@ where
             MysqlIntermediary::run_on_tcp(self, s)
         });
 
-        let mut db = mysql::Conn::new(&format!("mysql://127.0.0.1:{}", port)).unwrap();
+        let mut db =
+            mysql::Conn::new(Opts::from_url(&format!("mysql://127.0.0.1:{}", port)).unwrap())
+                .unwrap();
         c(&mut db);
         drop(db);
         jh.join().unwrap().unwrap();


### PR DESCRIPTION
This updates mysql_common to 0.28.0 and adjusts code accordingly.

This is the first of a number of independent PRs to upgrade various dependencies to recent versions.