### PR TITLE
Upgrade various async dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ time = "0.2.25"
 [dev-dependencies]
 postgres = "0.19.1"
 mysql = "18"
-mysql_async = "0.20.0"
+mysql_async = "0.29.0"
 slab = "0.4.2"
-tokio = "0.1.19"
-futures = "0.1.26"
+tokio = { version = "1.15.0", features = ["full"] }
+futures = "0.3.0"

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -104,7 +104,10 @@ where
             MysqlIntermediary::run_on_tcp(self, s)
         });
 
-        let rt = tokio::runtime::Runtime::new().unwrap();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
         rt.block_on(async {
             let conn = mysql_async::Conn::new(
                 Opts::from_url(&format!("mysql://127.0.0.1:{}", port)).unwrap(),
@@ -114,6 +117,7 @@ where
             c(conn).await
         })
         .unwrap();
+        rt.shutdown_background();
 
         jh.join().unwrap().unwrap();
     }

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -235,14 +235,12 @@ fn error_response() {
     )
     .test(|mut db| async move {
         let res: Result<Vec<mysql_async::Row>, _> = db.query("SELECT a, b FROM foo").await;
-
-        match res {
-            Ok(_) => assert!(false),
-            Err(mysql_async::Error::Server(mysql_async::ServerError {
+        match res.unwrap_err() {
+            mysql_async::Error::Server(mysql_async::ServerError {
                 code,
                 message: ref msg,
                 ref state,
-            })) => {
+            }) => {
                 assert_eq!(
                     state,
                     &String::from_utf8(err.0.sqlstate().to_vec()).unwrap()
@@ -250,11 +248,11 @@ fn error_response() {
                 assert_eq!(code, err.0 as u16);
                 assert_eq!(msg, &err.1);
             }
-            Err(e) => {
+            e => {
                 eprintln!("unexpected {:?}", e);
                 assert!(false);
             }
-        }
+        };
         Ok(())
     })
 }

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -6,8 +6,10 @@ extern crate mysql_common as myc;
 extern crate nom;
 extern crate tokio;
 
-use futures::{Future, IntoFuture};
 use mysql_async::prelude::*;
+use mysql_async::Opts;
+use std::error::Error;
+use std::future::Future;
 use std::io;
 use std::net;
 use std::thread;
@@ -92,8 +94,8 @@ where
 
     fn test<C, F>(self, c: C)
     where
-        F: IntoFuture<Item = (), Error = mysql_async::error::Error>,
-        C: FnOnce(mysql_async::Conn) -> F,
+        F: Future<Output = Result<(), Box<dyn Error>>> + 'static,
+        C: Fn(mysql_async::Conn) -> F,
     {
         let listener = net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
@@ -102,9 +104,15 @@ where
             MysqlIntermediary::run_on_tcp(self, s)
         });
 
-        tokio::runtime::current_thread::block_on_all(
-            mysql_async::Conn::new(format!("mysql://127.0.0.1:{}", port)).and_then(|conn| c(conn)),
-        )
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let conn = mysql_async::Conn::new(
+                Opts::from_url(&format!("mysql://127.0.0.1:{}", port)).unwrap(),
+            )
+            .await
+            .unwrap();
+            c(conn).await
+        })
         .unwrap();
 
         jh.join().unwrap().unwrap();
@@ -118,7 +126,7 @@ fn it_connects() {
         |_| unreachable!(),
         |_, _, _| unreachable!(),
     )
-    .test(|_| Ok(()))
+    .test(|_| async { Ok(()) })
 }
 
 #[test]
@@ -128,7 +136,10 @@ fn it_pings() {
         |_| unreachable!(),
         |_, _, _| unreachable!(),
     )
-    .test(|db| db.ping().map(|_| ()))
+    .test(|mut db| async move {
+        db.ping().await.map(|_| ())?;
+        Ok(())
+    })
 }
 
 #[test]
@@ -138,13 +149,10 @@ fn empty_response() {
         |_| unreachable!(),
         |_, _, _| unreachable!(),
     )
-    .test(|db| {
-        db.query("SELECT a, b FROM foo")
-            .and_then(|r| r.collect::<mysql_async::Row>())
-            .and_then(|(_, rs)| {
-                assert_eq!(rs.len(), 0);
-                Ok(())
-            })
+    .test(|mut db| async move {
+        let rs: Vec<mysql_async::Row> = db.query("SELECT a, b FROM foo").await?;
+        assert_eq!(rs.len(), 0);
+        Ok(())
     })
 }
 
@@ -161,13 +169,10 @@ fn no_rows() {
         |_| unreachable!(),
         |_, _, _| unreachable!(),
     )
-    .test(|db| {
-        db.query("SELECT a, b FROM foo")
-            .and_then(|r| r.collect::<mysql_async::Row>())
-            .and_then(|(_, rs)| {
-                assert_eq!(rs.len(), 0);
-                Ok(())
-            })
+    .test(|mut db| async move {
+        let rs: Vec<mysql_async::Row> = db.query("SELECT a, b FROM foo").await?;
+        assert_eq!(rs.len(), 0);
+        Ok(())
     })
 }
 
@@ -178,13 +183,10 @@ fn no_columns() {
         |_| unreachable!(),
         |_, _, _| unreachable!(),
     )
-    .test(|db| {
-        db.query("SELECT a, b FROM foo")
-            .and_then(|r| r.collect::<mysql_async::Row>())
-            .and_then(|(_, rs)| {
-                assert_eq!(rs.len(), 0);
-                Ok(())
-            })
+    .test(|mut db| async move {
+        let rs: Vec<mysql_async::Row> = db.query("SELECT a, b FROM foo").await?;
+        assert_eq!(rs.len(), 0);
+        Ok(())
     })
 }
 
@@ -195,13 +197,10 @@ fn no_columns_but_rows() {
         |_| unreachable!(),
         |_, _, _| unreachable!(),
     )
-    .test(|db| {
-        db.query("SELECT a, b FROM foo")
-            .and_then(|r| r.collect::<mysql_async::Row>())
-            .and_then(|(_, rs)| {
-                assert_eq!(rs.len(), 0);
-                Ok(())
-            })
+    .test(|mut db| async move {
+        let rs: Vec<mysql_async::Row> = db.query("SELECT a, b FROM foo").await?;
+        assert_eq!(rs.len(), 0);
+        Ok(())
     })
 }
 
@@ -216,7 +215,10 @@ fn really_long_query() {
         |_| unreachable!(),
         |_, _, _| unreachable!(),
     )
-    .test(move |db| db.drop_query(long).map(|_| ()))
+    .test(move |mut db| async move {
+        db.query_drop(long).await?;
+        Ok(())
+    })
 }
 
 #[test]
@@ -227,29 +229,29 @@ fn error_response() {
         |_| unreachable!(),
         |_, _, _| unreachable!(),
     )
-    .test(|db| {
-        db.query("SELECT a, b FROM foo").then(|r| {
-            match r {
-                Ok(_) => assert!(false),
-                Err(mysql_async::error::Error::Server(mysql_async::error::ServerError {
-                    code,
-                    message: ref msg,
-                    ref state,
-                })) => {
-                    assert_eq!(
-                        state,
-                        &String::from_utf8(err.0.sqlstate().to_vec()).unwrap()
-                    );
-                    assert_eq!(code, err.0 as u16);
-                    assert_eq!(msg, &err.1);
-                }
-                Err(e) => {
-                    eprintln!("unexpected {:?}", e);
-                    assert!(false);
-                }
+    .test(|mut db| async move {
+        let res: Result<Vec<mysql_async::Row>, _> = db.query("SELECT a, b FROM foo").await;
+
+        match res {
+            Ok(_) => assert!(false),
+            Err(mysql_async::Error::Server(mysql_async::ServerError {
+                code,
+                message: ref msg,
+                ref state,
+            })) => {
+                assert_eq!(
+                    state,
+                    &String::from_utf8(err.0.sqlstate().to_vec()).unwrap()
+                );
+                assert_eq!(code, err.0 as u16);
+                assert_eq!(msg, &err.1);
             }
-            Ok(())
-        })
+            Err(e) => {
+                eprintln!("unexpected {:?}", e);
+                assert!(false);
+            }
+        }
+        Ok(())
     })
 }
 
@@ -266,13 +268,10 @@ fn empty_on_drop() {
         |_| unreachable!(),
         |_, _, _| unreachable!(),
     )
-    .test(|db| {
-        db.query("SELECT a, b FROM foo")
-            .and_then(|r| r.collect::<mysql_async::Row>())
-            .and_then(|(_, rs)| {
-                assert_eq!(rs.len(), 0);
-                Ok(())
-            })
+    .test(|mut db| async move {
+        let rs: Vec<mysql_async::Row> = db.query("SELECT a, b FROM foo").await?;
+        assert_eq!(rs.len(), 0);
+        Ok(())
     })
 }
 
@@ -293,15 +292,12 @@ fn it_queries_nulls() {
         |_| unreachable!(),
         |_, _, _| unreachable!(),
     )
-    .test(|db| {
-        db.query("SELECT a, b FROM foo")
-            .and_then(|r| r.collect::<mysql_async::Row>())
-            .and_then(|(_, rs)| {
-                assert_eq!(rs.len(), 1);
-                assert_eq!(rs[0].len(), 1);
-                assert_eq!(rs[0][0], mysql_async::Value::NULL);
-                Ok(())
-            })
+    .test(|mut db| async move {
+        let rs: Vec<mysql_async::Row> = db.query("SELECT a, b FROM foo").await?;
+        assert_eq!(rs.len(), 1);
+        assert_eq!(rs[0].len(), 1);
+        assert_eq!(rs[0][0], mysql_async::Value::NULL);
+        Ok(())
     })
 }
 
@@ -322,15 +318,12 @@ fn it_queries() {
         |_| unreachable!(),
         |_, _, _| unreachable!(),
     )
-    .test(|db| {
-        db.query("SELECT a, b FROM foo")
-            .and_then(|r| r.collect::<mysql_async::Row>())
-            .and_then(|(_, rs)| {
-                assert_eq!(rs.len(), 1);
-                assert_eq!(rs[0].len(), 1);
-                assert_eq!(rs[0].get::<i16, _>(0), Some(1024));
-                Ok(())
-            })
+    .test(|mut db| async move {
+        let rs: Vec<mysql_async::Row> = db.query("SELECT a, b FROM foo").await?;
+        assert_eq!(rs.len(), 1);
+        assert_eq!(rs[0].len(), 1);
+        assert_eq!(rs[0].get::<i16, _>(0), Some(1024));
+        Ok(())
     })
 }
 
@@ -362,19 +355,16 @@ fn it_queries_many_rows() {
         |_| unreachable!(),
         |_, _, _| unreachable!(),
     )
-    .test(|db| {
-        db.query("SELECT a, b FROM foo")
-            .and_then(|r| r.collect::<mysql_async::Row>())
-            .and_then(|(_, rs)| {
-                assert_eq!(rs.len(), 2);
-                assert_eq!(rs[0].len(), 2);
-                assert_eq!(rs[0].get::<i16, _>(0), Some(1024));
-                assert_eq!(rs[0].get::<i16, _>(1), Some(1025));
-                assert_eq!(rs[1].len(), 2);
-                assert_eq!(rs[1].get::<i16, _>(0), Some(1024));
-                assert_eq!(rs[1].get::<i16, _>(1), Some(1025));
-                Ok(())
-            })
+    .test(|mut db| async move {
+        let rs: Vec<mysql_async::Row> = db.query("SELECT a, b FROM foo").await?;
+        assert_eq!(rs.len(), 2);
+        assert_eq!(rs[0].len(), 2);
+        assert_eq!(rs[0].get::<i16, _>(0), Some(1024));
+        assert_eq!(rs[0].get::<i16, _>(1), Some(1025));
+        assert_eq!(rs[1].len(), 2);
+        assert_eq!(rs[1].get::<i16, _>(0), Some(1024));
+        assert_eq!(rs[1].get::<i16, _>(1), Some(1025));
+        Ok(())
     })
 }
 
@@ -417,15 +407,14 @@ fn it_prepares() {
     )
     .with_params(params)
     .with_columns(cols2)
-    .test(|db| {
-        db.prep_exec("SELECT a FROM b WHERE c = ?", (42i16,))
-            .and_then(|r| r.collect::<mysql_async::Row>())
-            .and_then(|(_, rs)| {
-                assert_eq!(rs.len(), 1);
-                assert_eq!(rs[0].len(), 1);
-                assert_eq!(rs[0].get::<i16, _>(0), Some(1024));
-                Ok(())
-            })
+    .test(|mut db| async move {
+        let prep = db.prep("SELECT a FROM b WHERE c = ?").await?;
+        let rs: Vec<mysql_async::Row> = db.exec(prep, (42i16,)).await?;
+        assert_eq!(rs.len(), 1);
+        assert_eq!(rs[0].len(), 1);
+        assert_eq!(rs[0].get::<i16, _>(0), Some(1024));
+
+        Ok(())
     })
 }
 
@@ -527,27 +516,34 @@ fn insert_exec() {
         },
     )
     .with_params(params)
-    .test(|db| {
-        db.prep_exec(
-            "INSERT INTO `users` \
-             (`username`, `email`, `password_digest`, `created_at`, \
-             `session_token`, `rss_token`, `mailing_list_token`) \
-             VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (
-                "user199",
-                "user199@example.com",
-                "$2a$10$Tq3wrGeC0xtgzuxqOlc3v.07VTUvxvwI70kuoVihoO2cE5qj7ooka",
-                mysql_async::Value::Date(2018, 4, 6, 13, 0, 56, 0),
-                "token199",
-                "rsstoken199",
-                "mtok199",
-            ),
-        )
-        .and_then(|res| {
-            assert_eq!(res.affected_rows(), 42);
-            assert_eq!(res.last_insert_id(), Some(1));
-            Ok(())
-        })
+    .test(|mut db| async move {
+        let prep = db
+            .prep(
+                "INSERT INTO `users` \
+        (`username`, `email`, `password_digest`, `created_at`, \
+        `session_token`, `rss_token`, `mailing_list_token`) \
+        VALUES (?, ?, ?, ?, ?, ?, ?)",
+            )
+            .await?;
+
+        let _res: Vec<mysql_async::Row> = db
+            .exec(
+                prep,
+                (
+                    "user199",
+                    "user199@example.com",
+                    "$2a$10$Tq3wrGeC0xtgzuxqOlc3v.07VTUvxvwI70kuoVihoO2cE5qj7ooka",
+                    mysql_async::Value::Date(2018, 4, 6, 13, 0, 56, 0),
+                    "token199",
+                    "rsstoken199",
+                    "mtok199",
+                ),
+            )
+            .await?;
+
+        assert_eq!(db.affected_rows(), 42);
+        assert_eq!(db.last_insert_id(), Some(1));
+        Ok(())
     })
 }
 
@@ -590,15 +586,14 @@ fn send_long() {
     )
     .with_params(params)
     .with_columns(cols2)
-    .test(|db| {
-        db.prep_exec("SELECT a FROM b WHERE c = ?", (b"Hello world",))
-            .and_then(|r| r.collect::<mysql_async::Row>())
-            .and_then(|(_, rs)| {
-                assert_eq!(rs.len(), 1);
-                assert_eq!(rs[0].len(), 1);
-                assert_eq!(rs[0].get::<i16, _>(0), Some(1024));
-                Ok(())
-            })
+    .test(|mut db| async move {
+        let prep = db.prep("SELECT a FROM b WHERE c = ?").await?;
+        let rs: Vec<mysql_async::Row> = db.exec(prep, (b"Hello world",)).await?;
+
+        assert_eq!(rs.len(), 1);
+        assert_eq!(rs[0].len(), 1);
+        assert_eq!(rs[0].get::<i16, _>(0), Some(1024));
+        Ok(())
     })
 }
 
@@ -640,19 +635,17 @@ fn it_prepares_many() {
     )
     .with_params(Vec::new())
     .with_columns(cols2)
-    .test(|db| {
-        db.prep_exec("SELECT a, b FROM x", ())
-            .and_then(|r| r.collect::<mysql_async::Row>())
-            .and_then(|(_, rs)| {
-                assert_eq!(rs.len(), 2);
-                assert_eq!(rs[0].len(), 2);
-                assert_eq!(rs[0].get::<i16, _>(0), Some(1024));
-                assert_eq!(rs[0].get::<i16, _>(1), Some(1025));
-                assert_eq!(rs[1].len(), 2);
-                assert_eq!(rs[1].get::<i16, _>(0), Some(1024));
-                assert_eq!(rs[1].get::<i16, _>(1), Some(1025));
-                Ok(())
-            })
+    .test(|mut db| async move {
+        let prep = db.prep("SELECT a, b FROM x").await?;
+        let rs: Vec<mysql_async::Row> = db.exec(prep, ()).await?;
+        assert_eq!(rs.len(), 2);
+        assert_eq!(rs[0].len(), 2);
+        assert_eq!(rs[0].get::<i16, _>(0), Some(1024));
+        assert_eq!(rs[0].get::<i16, _>(1), Some(1025));
+        assert_eq!(rs[1].len(), 2);
+        assert_eq!(rs[1].get::<i16, _>(0), Some(1024));
+        assert_eq!(rs[1].get::<i16, _>(1), Some(1025));
+        Ok(())
     })
 }
 
@@ -682,13 +675,11 @@ fn prepared_empty() {
     )
     .with_params(params)
     .with_columns(cols2)
-    .test(|db| {
-        db.prep_exec("SELECT a FROM b WHERE c = ?", (42i16,))
-            .and_then(|r| r.collect::<mysql_async::Row>())
-            .and_then(|(_, rs)| {
-                assert_eq!(rs.len(), 0);
-                Ok(())
-            })
+    .test(|mut db| async move {
+        let prep = db.prep("SELECT a FROM b WHERE c = ?").await.unwrap();
+        let rs: Vec<mysql_async::Row> = db.exec(prep, (42i16,)).await?;
+        assert_eq!(rs.len(), 0);
+        Ok(())
     })
 }
 
@@ -715,15 +706,13 @@ fn prepared_no_params() {
     )
     .with_params(params)
     .with_columns(cols2)
-    .test(|db| {
-        db.prep_exec("foo", ())
-            .and_then(|r| r.collect::<mysql_async::Row>())
-            .and_then(|(_, rs)| {
-                assert_eq!(rs.len(), 1);
-                assert_eq!(rs[0].len(), 1);
-                assert_eq!(rs[0].get::<i16, _>(0), Some(1024));
-                Ok(())
-            })
+    .test(|mut db| async move {
+        let prep = db.prep("foo").await.unwrap();
+        let rs: Vec<mysql_async::Row> = db.exec(prep, ()).await?;
+        assert_eq!(rs.len(), 1);
+        assert_eq!(rs[0].len(), 1);
+        assert_eq!(rs[0].get::<i16, _>(0), Some(1024));
+        Ok(())
     })
 }
 
@@ -768,7 +757,7 @@ fn prepared_nulls() {
             assert!(!params[1].value.is_null());
             assert_eq!(
                 params[0].coltype,
-                myc::constants::ColumnType::MYSQL_TYPE_SHORT
+                myc::constants::ColumnType::MYSQL_TYPE_NULL
             );
             // rust-mysql sends all numbers as LONGLONG :'(
             assert_eq!(
@@ -784,19 +773,14 @@ fn prepared_nulls() {
     )
     .with_params(params)
     .with_columns(cols2)
-    .test(|db| {
-        db.prep_exec(
-            "SELECT a, b FROM x WHERE c = ? AND d = ?",
-            (mysql_async::Value::NULL, 42),
-        )
-        .and_then(|r| r.collect::<mysql_async::Row>())
-        .and_then(|(_, rs)| {
-            assert_eq!(rs.len(), 1);
-            assert_eq!(rs[0].len(), 2);
-            assert_eq!(rs[0].get::<Option<i16>, _>(0), Some(None));
-            assert_eq!(rs[0].get::<i16, _>(1), Some(42));
-            Ok(())
-        })
+    .test(|mut db| async move {
+        let prep = db.prep("SELECT a, b FROM x WHERE c = ? AND d = ?").await?;
+        let rs: Vec<mysql_async::Row> = db.exec(prep, (mysql_async::Value::NULL, 42)).await?;
+        assert_eq!(rs.len(), 1);
+        assert_eq!(rs[0].len(), 2);
+        assert_eq!(rs[0].get::<Option<i16>, _>(0), Some(None));
+        assert_eq!(rs[0].get::<i16, _>(1), Some(42));
+        Ok(())
     })
 }
 
@@ -815,13 +799,11 @@ fn prepared_no_rows() {
         move |_, _, w| w.start(&cols[..])?.finish(),
     )
     .with_columns(cols2)
-    .test(|db| {
-        db.prep_exec("SELECT a, b FROM foo", ())
-            .and_then(|r| r.collect::<mysql_async::Row>())
-            .and_then(|(_, rs)| {
-                assert_eq!(rs.len(), 0);
-                Ok(())
-            })
+    .test(|mut db| async move {
+        let prep = db.prep("SELECT a, b FROM foo").await?;
+        let rs: Vec<mysql_async::Row> = db.exec(prep, ()).await?;
+        assert_eq!(rs.len(), 0);
+        Ok(())
     })
 }
 
@@ -832,13 +814,11 @@ fn prepared_no_cols_but_rows() {
         |_| 0,
         move |_, _, w| w.start(&[])?.write_col(42).map(|_| ()),
     )
-    .test(|db| {
-        db.prep_exec("SELECT a, b FROM foo", ())
-            .and_then(|r| r.collect::<mysql_async::Row>())
-            .and_then(|(_, rs)| {
-                assert_eq!(rs.len(), 0);
-                Ok(())
-            })
+    .test(|mut db| async move {
+        let prep = db.prep("SELECT a, b FROM foo").await?;
+        let rs: Vec<mysql_async::Row> = db.exec(prep, ()).await?;
+        assert_eq!(rs.len(), 0);
+        Ok(())
     })
 }
 
@@ -849,12 +829,10 @@ fn prepared_no_cols() {
         |_| 0,
         move |_, _, w| w.start(&[])?.finish(),
     )
-    .test(|db| {
-        db.prep_exec("SELECT a, b FROM foo", ())
-            .and_then(|r| r.collect::<mysql_async::Row>())
-            .and_then(|(_, rs)| {
-                assert_eq!(rs.len(), 0);
-                Ok(())
-            })
+    .test(|mut db| async move {
+        let prep = db.prep("SELECT a, b FROM foo").await?;
+        let rs: Vec<mysql_async::Row> = db.exec(prep, ()).await?;
+        assert_eq!(rs.len(), 0);
+        Ok(())
     })
 }

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -523,10 +523,9 @@ fn insert_exec() {
     .test(|mut db| async move {
         let prep = db
             .prep(
-                "INSERT INTO `users` \
-        (`username`, `email`, `password_digest`, `created_at`, \
-        `session_token`, `rss_token`, `mailing_list_token`) \
-        VALUES (?, ?, ?, ?, ?, ?, ?)",
+                "INSERT INTO `users` (`username`, `email`, `password_digest`, \
+                     `created_at`, `session_token`, `rss_token`, `mailing_list_token`) \
+                      VALUES (?, ?, ?, ?, ?, ?, ?)",
             )
             .await?;
 


### PR DESCRIPTION
This upgrades tokio, futures & mysql_async to recent versions.  Doing so
involved reworking the async code in the tests to use the modern rust
async/await style, and updating code to work with the more recent
method names in mysql_async.