### PR TITLE
Remove `time dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ nom = "7"
 mysql_common = { version = "0.28.0", features = ["chrono"] }
 byteorder = "1"
 chrono = "0.4"
-time = "0.2.25"
 rustls = {version = "0.20.0", optional=true}
 
 [dev-dependencies]


### PR DESCRIPTION
Remove `time dependency because it is unused.