### PR TITLE
Fix compile by upgrading mysql crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,15 +28,15 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 nom = "7"
-mysql_common = { version = "0.28.0", features = ["chrono"] }
+mysql_common = { version = "0.29.1", features = ["chrono"] }
 byteorder = "1"
 chrono = "0.4"
 rustls = {version = "0.20.0", optional=true}
 
 [dev-dependencies]
 postgres = "0.19.1"
-mysql = "22"
-mysql_async = "0.29.0"
+mysql = "23"
+mysql_async = "0.31.0"
 slab = "0.4.2"
 tokio = { version = "1.15.0", features = ["full"] }
 futures = "0.3.0"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 jobs:
   - template: default.yml@templates
     parameters:
-      minrust: 1.54
+      minrust: 1.59
       codecov_token: $(CODECOV_TOKEN_SECRET)
 
 resources:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,7 @@ pub trait MysqlShim<W: Read + Write> {
 }
 
 /// Information about an authenticated user
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct AuthenticationContext<'a> {
     /// The username exactly as passed by the client,
     pub username: Option<Vec<u8>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,8 @@ pub trait MysqlShim<W: Read + Write> {
 }
 
 /// Information about an authenticated user
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct AuthenticationContext<'a> {
     /// The username exactly as passed by the client,
     pub username: Option<Vec<u8>>,

--- a/src/params.rs
+++ b/src/params.rs
@@ -73,11 +73,10 @@ impl<'a> Iterator for Params<'a> {
                 self.bound_types.clear();
                 for i in 0..self.params as usize {
                     self.bound_types.push((
-                        myc::constants::ColumnType::try_from(typmap[2 * i as usize])
-                            .unwrap_or_else(|e| {
-                                panic!("bad column type 0x{:x}: {}", typmap[2 * i as usize], e)
-                            }),
-                        (typmap[2 * i as usize + 1] & 128) != 0,
+                        myc::constants::ColumnType::try_from(typmap[2 * i]).unwrap_or_else(|e| {
+                            panic!("bad column type 0x{:x}: {}", typmap[2 * i], e)
+                        }),
+                        (typmap[2 * i + 1] & 128) != 0,
                     ));
                 }
                 self.input = rest;

--- a/src/value/encode.rs
+++ b/src/value/encode.rs
@@ -723,15 +723,14 @@ mod tests {
         rt!(opt_none, Option<u8>, None);
         rt!(opt_some, Option<u8>, Some(1));
 
-        rt!(
-            time,
-            chrono::NaiveDate,
-            chrono::Local::today().naive_local()
-        );
+        rt!(time, chrono::NaiveDate, chrono::Local::now().date_naive());
         rt!(
             datetime,
             chrono::NaiveDateTime,
-            chrono::Utc.ymd(1989, 12, 7).and_hms(8, 0, 4).naive_utc()
+            chrono::Utc
+                .with_ymd_and_hms(1989, 12, 7, 8, 0, 4)
+                .unwrap()
+                .naive_utc()
         );
         rt!(dur, time::Duration, time::Duration::from_secs(1893));
         rt!(dur_micro, time::Duration, time::Duration::new(1893, 5000));
@@ -915,13 +914,16 @@ mod tests {
         rt!(
             time,
             chrono::NaiveDate,
-            chrono::Local::today().naive_local(),
+            chrono::Local::now().date_naive(),
             ColumnType::MYSQL_TYPE_DATE
         );
         rt!(
             datetime,
             chrono::NaiveDateTime,
-            chrono::Utc.ymd(1989, 12, 7).and_hms(8, 0, 4).naive_utc(),
+            chrono::Utc
+                .with_ymd_and_hms(1989, 12, 7, 8, 0, 4)
+                .unwrap()
+                .naive_utc(),
             ColumnType::MYSQL_TYPE_DATETIME
         );
         rt!(

--- a/src/value/encode.rs
+++ b/src/value/encode.rs
@@ -392,10 +392,10 @@ impl ToMysqlValue for [u8] {
 
 impl ToMysqlValue for Vec<u8> {
     fn to_mysql_text<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        (&self[..]).to_mysql_text(w)
+        (self[..]).to_mysql_text(w)
     }
     fn to_mysql_bin<W: Write>(&self, w: &mut W, c: &Column) -> io::Result<()> {
-        (&self[..]).to_mysql_bin(w, c)
+        (self[..]).to_mysql_bin(w, c)
     }
 }
 
@@ -563,8 +563,10 @@ impl ToMysqlValue for myc::value::Value {
             myc::value::Value::Float(f) => f.to_mysql_text(w),
             myc::value::Value::Double(f) => f.to_mysql_text(w),
             myc::value::Value::Date(y, mo, d, h, mi, s, us) => {
-                NaiveDate::from_ymd(i32::from(y), u32::from(mo), u32::from(d))
-                    .and_hms_micro(u32::from(h), u32::from(mi), u32::from(s), us)
+                NaiveDate::from_ymd_opt(i32::from(y), u32::from(mo), u32::from(d))
+                    .unwrap_or_else(|| panic!("invalid date: y {} mo {} d {}", y, mo, d))
+                    .and_hms_micro_opt(u32::from(h), u32::from(mi), u32::from(s), us)
+                    .unwrap_or_else(|| panic!("invalid date: h {} mi {} s {} us {}", h, mi, s, us))
                     .to_mysql_text(w)
             }
             myc::value::Value::Time(neg, d, h, m, s, us) => {
@@ -628,8 +630,10 @@ impl ToMysqlValue for myc::value::Value {
             myc::value::Value::Float(f) => f.to_mysql_bin(w, c),
             myc::value::Value::Double(f) => f.to_mysql_bin(w, c),
             myc::value::Value::Date(y, mo, d, h, mi, s, us) => {
-                NaiveDate::from_ymd(i32::from(y), u32::from(mo), u32::from(d))
-                    .and_hms_micro(u32::from(h), u32::from(mi), u32::from(s), us)
+                NaiveDate::from_ymd_opt(i32::from(y), u32::from(mo), u32::from(d))
+                    .unwrap_or_else(|| panic!("invalid date: y {} mo {} d {}", y, mo, d))
+                    .and_hms_micro_opt(u32::from(h), u32::from(mi), u32::from(s), us)
+                    .unwrap_or_else(|| panic!("invalid date: h {} mi {} s {} us {}", h, mi, s, us))
                     .to_mysql_bin(w, c)
             }
             myc::value::Value::Time(neg, d, h, m, s, us) => {

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -508,7 +508,10 @@ fn insert_exec() {
             );
             assert_eq!(
                 Into::<chrono::NaiveDateTime>::into(params[3].value),
-                chrono::NaiveDate::from_ymd(2018, 4, 6).and_hms(13, 0, 56)
+                chrono::NaiveDate::from_ymd_opt(2018, 4, 6)
+                    .unwrap()
+                    .and_hms_opt(13, 0, 56)
+                    .unwrap()
             );
             assert_eq!(Into::<&str>::into(params[4].value), "token199");
             assert_eq!(Into::<&str>::into(params[5].value), "rsstoken199");

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -147,7 +147,6 @@ where
     #[cfg(all(feature = "tls", unix))]
     fn with_tls(mut self, client: bool, server: bool, use_client_certs: bool) -> Self {
         use std::fs::File;
-        use std::io::Write;
 
         use mysql::ClientIdentity;
 
@@ -998,7 +997,10 @@ fn insert_exec() {
             );
             assert_eq!(
                 Into::<chrono::NaiveDateTime>::into(params[3].value),
-                chrono::NaiveDate::from_ymd(2018, 4, 6).and_hms(13, 0, 56)
+                chrono::NaiveDate::from_ymd_opt(2018, 4, 6)
+                    .unwrap()
+                    .and_hms_opt(13, 0, 56)
+                    .unwrap()
             );
             assert_eq!(Into::<&str>::into(params[4].value), "token199");
             assert_eq!(Into::<&str>::into(params[5].value), "rsstoken199");


### PR DESCRIPTION
@jonhoo  Could the minimum rust version be upgrade to 1.59.0?
Since `time v0.3.15` which needed by  `mysql_common v0.29.1` needs newer than 1.59.0 .